### PR TITLE
Updates to the info site following the publication of the v0.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the information site/repository for the **did:webvh ("`did:web` + Verifi
 
 `did:webvh` information is published at [https://didwebvh.info](https://didwebvh.info)
 
-The `did:webvh` specification is published at [https://identity.foundation/didwebvh](https://identity.foundation/didwebvh/next)
+The `did:webvh` specification is published at [https://identity.foundation/didwebvh](https://identity.foundation/didwebvh)
 
 ## Contributing
 

--- a/docs/didwebvh-server.md
+++ b/docs/didwebvh-server.md
@@ -2,7 +2,7 @@
 
 This server is built with the FastAPI framework.
 
-The did:webvh spec: [https://identity.foundation/didwebvh/next](https://identity.foundation/didwebvh/next)
+The did:webvh spec: [https://identity.foundation/didwebvh](https://identity.foundation/didwebvh)
 
 ## Abstract
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -1,6 +1,6 @@
 !!! warning
 
-    The set of examples here use the older `did:tdw` DID Method name, and v0.4 of the `did:webvh` specification. This example will be updated with the new [v0.5 did:webvh specification](https://identity.foundation/didwebvh/next) as soon as the implementations catch up to the specification.
+    The set of examples here use the older `did:tdw` DID Method name, and v0.4 of the `did:webvh` specification. This example will be updated with the new [v0.5 did:webvh specification](https://identity.foundation/didwebvh) as soon as the implementations catch up to the specification.
 
 The following covers the evolution of a `did:tdw` from inception through several
 versions, showing the DID, DIDDoc, DID Log, and some of the
@@ -15,13 +15,13 @@ Lines convention.
 
 ### DID Creation Data
 
-These examples show the important structures used in the [Create (Register)](https://identity.foundation/trustdidweb/#create-register) operation for a `did:tdw` DID.
+These examples show the important structures used in the [Create (Register)](https://identity.foundation/didwebvh/#create-register) operation for a `did:tdw` DID.
 
 #### Input to the SCID Generation Process with Placeholders
 
 The following JSON is an example of the input that the DID Controller
 constructs and passes into the
-[SCID Generation Process](https://identity.foundation/trustdidweb/#scid-generation-and-verification). In this example, the DIDDoc is
+[SCID Generation Process](https://identity.foundation/didwebvh/#scid-generation-and-verification). In this example, the DIDDoc is
 particularly boring, containing the absolute minimum for a valid DIDDoc.
 
 This example includes both the initial "authorized keys" to sign the Data Integrity proof
@@ -57,7 +57,7 @@ are in the `parameters` property in the log entry.
 After the SCID is generated, the literal `{SCID}` placeholders are
 replaced by the generated SCID value (see below). This JSON is the
 input to the [`entryHash` generation
-process](https://identity.foundation/trustdidweb/#entry-hash-generation-and-verification) -- with the SCID
+process](https://identity.foundation/didwebvh/#entry-hash-generation-and-verification) -- with the SCID
 `versionId``. Once the process has run, the version number of this first version
 of the DID (`1`), a dash `-` and the resulting output hash replace the [[ref:
 SCID as the `versionId` value.
@@ -143,7 +143,7 @@ The same content "un-prettified", as it is found in the `did.jsonl` file:
 #### `did:web` Version of DIDDoc
 
 As noted in the [publishing a parallel `did:web`
-DID](https://identity.foundation/trustdidweb/#publishing-a-parallel-didweb-did) section of this specification a `did:tdw` can be published
+DID](https://identity.foundation/didwebvh/#publishing-a-parallel-didweb-did) section of this specification a `did:tdw` can be published
 by replacing `did:tdw` with `did:web` in the DIDDoc, adding an `alsoKnownAs` entry for the `did:tdw`
 and publishing the resulting DIDDoc at `did.json`, logically beside the `did.jsonl` file.
 
@@ -182,7 +182,7 @@ found in the `nextKeyHashes` property from version 1 of the DID. As required by 
 `did:tdw` specification, a new `nextKeyHashes` is included in the new `parameters`.
 - The new (but unchanged) DIDDoc is included in its entirety, as the value of the `state` property.
 - The resultant JSON object is passed into the [`entryHash` generation
-  process](https://identity.foundation/trustdidweb/#entry-hash-generation-and-verification) which outputs the
+  process](https://identity.foundation/didwebvh/#entry-hash-generation-and-verification) which outputs the
   `entryHash` for this log entry. Once again, the `versionId` value is
   replaced by the version number (the previous version number plus `1`, so `2`
   in this case), a dash (`-`), and the new `entryHash`.

--- a/docs/implementations.md
+++ b/docs/implementations.md
@@ -2,10 +2,10 @@
 
 Implementations of `did:webvh` software for DID Controller registrars and resolvers can be found here:
 
-- [Typescript](https://github.com/decentralized-identity/trustdidweb-ts)
-- [Python](https://github.com/decentralized-identity/trustdidweb-py)
+- [Typescript](https://github.com/decentralized-identity/didwebvh-ts)
+- [Python](https://github.com/decentralized-identity/didwebvh-py)
 - [Go](https://github.com/nuts-foundation/trustdidweb-go)
-- [`did:webvh` Server - Python](https://github.com/decentralized-identity/trustdidweb-server-py)
+- [`did:webvh` Server - Python](https://github.com/decentralized-identity/didwebvh-server-py)
 
 The implementations support most of the features of the core `did:webvh` (including
 key pre-rotation and witnesses) to the v0.4 version of the specification.

--- a/docs/implementers-guide/did-portability.md
+++ b/docs/implementers-guide/did-portability.md
@@ -1,6 +1,6 @@
 # DID Portability
 
-As noted in the [DID Portability](https://identity.foundation/trustdidweb/#did-portability) section of the
+As noted in the [DID Portability](https://identity.foundation/didwebvh/#did-portability) section of the
 specification, a `did:webvh` DID can be renamed (ported) by changing the `id` DID string in
 the DIDDoc to one that resolves to a different HTTPS URL, as long as the
 specified conditions are met.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -78,7 +78,7 @@ security assurances provided by `did:webvh`.
     - SCID := `base58btc(multihash(JCS(preliminary log entry with placeholders), <hash algorithm>))`
         - `JCS` := an implementation of the JSON Canonicalization Scheme ([RFC8785](https://www.rfc-editor.org/info/rfc8785))
         - `multihash` := an implementation of the [multihash](https://multiformats.io/multihash/) specification
-        - `<hash algorithm>` := one of the hash algorithms accepted by  `did:webvh` (see [parameters](https://identity.foundation/didwebvh/next/#didwebvh-did-method-parameters) in the specification)
+        - `<hash algorithm>` := one of the hash algorithms accepted by  `did:webvh` (see [parameters](https://identity.foundation/didwebvh/#didwebvh-did-method-parameters) in the specification)
         - `base58btc` := an implementation of the [base58btc](https://datatracker.ietf.org/doc/html/draft-msporny-base58-03) function
 
 3. Update the preliminary log entry

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,7 +1,7 @@
 # The `did:webvh` DID Method Specification
 
 Here is a live version of the `did:webvh` specification. You probably want to open up
-a new browser window to see the [published](https://identity.foundation/didwebvh/next) spec, but if you
+a new browser window to see the [published](https://identity.foundation/didwebvh) spec, but if you
 just want to scan some things -- here you go!
 
-<iframe src="https://identity.foundation/didwebvh/next" width="100%" height="800" frameborder="0"></iframe>
+<iframe src="https://identity.foundation/didwebvh" width="100%" height="800" frameborder="0"></iframe>

--- a/docs/version.md
+++ b/docs/version.md
@@ -3,4 +3,4 @@
 The following lists the substantive changes in each version of the
 specification, as included in the specification.
 
-<iframe src="https://identity.foundation/didwebvh/next/#didwebvh-version-changelog" width="100%" height="800" frameborder="0"></iframe>
+<iframe src="https://identity.foundation/didwebvh/#didwebvh-version-changelog" width="100%" height="800" frameborder="0"></iframe>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,7 @@ nav:
     - did:webvh DID Log Example: example.md
 - Implementations:
     - did:webvh Registrars/Resolvers: implementations.md
-    - did:webvh Web Server: trustdidweb-server.md
+    - did:webvh Web Server: didwebvh-server.md
 - Demos:
     - did:webvh Demos: demos/README.md
 - Contributing:


### PR DESCRIPTION
- Makes the published spec landing page the default ("/") vs. next that was used while v0.5 was being defined.
- Changes a number of links from being in the "trustdidweb" spec to the "didwebvh" spec. Even tested them all (I think...)
- Updates to the links to the implementations and the name of the local didwebvh-server documentation page.
