### PR TITLE
Update implementations and deployments

### DIFF
--- a/docs/implementations/README.md
+++ b/docs/implementations/README.md
@@ -7,7 +7,7 @@ Implementations of `did:webvh` software for DID Controller registrars, resolvers
 - [Nuts Foundation] -- [Go](https://github.com/nuts-foundation/trustdidweb-go) (Registrar/Resolver)
 - [DIF] -- [Rust](https://github.com/decentralized-identity/didwebvh-rs)  (Registrar/Resolver)
 - [Procivis] -- [Rust](https://github.com/procivis/one-core/tree/main/lib/one-core/src/provider/did_method/webvh) (Resolver)
-- [Affinidi] -- [Rust](https://github.com/affinidi/affinidi-tdk-rs/tree/main/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh) (Resolver)
+- [Affinidi] -- [Rust](https://github.com/affinidi/affinidi-tdk-rs/tree/main/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh), [Crate](https://crates.io/crates/did-webvh) (Resolver)
 - [DIF] -- [`did:webvh` Server - Python](https://github.com/decentralized-identity/didwebvh-server-py) (Server)
 - [DIF] -- [`did:webvh` Watcher - Python](https://github.com/decentralized-identity/didwebvh-watcher-py) (Watcher)
 - [OWF] -- [ACA-Py Plugin for `did:webvh`]([did:webvh ACA-Py Plugin]: https://github.com/openwallet-foundation/acapy-plugins/tree/main/webvh) (DID Controller/Resolver Framework)

--- a/docs/implementations/deployments.md
+++ b/docs/implementations/deployments.md
@@ -3,7 +3,12 @@
 The following is a list of the known deployments of `did:webvh` software. If you have a deployment that is not listed here, please let us know (or submit a PR). It is really helpful to the community to know about deployments so that we can learn from each other and build a larger network.
 
 - [Government of British Columbia Digital Trust] -- Currently deploying a test `did:webvh` Server capable of supporting `did:webvh` DIDs and Verifiable Credentials, including privacy-preserving [AnonCreds] verifiable credentials. The server is being developed in Python, deployed to a container orchestration environment, and intended to be used to support the BC Gov's digital identity initiatives. Support for did:webbvh is also being added to the [BC Wallet], a mobile wallet application for British Columbia residents.
+- The Swiss e-Id project have stated that the proposed Swiss e-Id Technical Stack will include did:webvh, as per [this announcement].
+- Companies such as [Affinidi] and [Procivis] have developed open source implementations of `did:webvh` for their clients.
 
 [Government of British Columbia Digital Trust]: https://www2.gov.bc.ca/gov/content/governments/government-id
 [AnonCreds]: https://www.lfdecentralizedtrust.org/projects/anoncreds
 [BC Wallet]: https://www2.gov.bc.ca/gov/content/governments/government-id/bc-wallet
+[this announcement]: https://swiyu-admin-ch.github.io/technology-stack/
+[Procivis]: https://procivis.ch
+[Affinidi]: https://affinidi.com


### PR DESCRIPTION
Adds a reference to the Swiss e-Id announcement, adds Affinidi and Procivis as deployments, and adds the Affinidi crate link.
