### PR TITLE
Updated FAQ section with performance and why the witness file added

### DIFF
--- a/docs/faq/JSONLines.md
+++ b/docs/faq/JSONLines.md
@@ -1,10 +1,8 @@
-# Frequently Asked Questions
-
-## Why JSON Lines?
+# Why JSON Lines?
 
 JSON Lines (newline-delimited JSON) is a format where each line is a valid JSON object. It’s widely used in data streaming, logging, and large-scale data processing.
 
-### Benefits of JSON Lines
+## Benefits of JSON Lines
 
 **1. Streaming-Friendly**  
 JSON Lines allows data to be processed one entry at a time. This means applications can handle very large datasets without loading everything into memory.
@@ -12,13 +10,16 @@ JSON Lines allows data to be processed one entry at a time. This means applicati
 **2. Incremental Parsing**  
 Each line is self-contained. Parsers can begin consuming data as soon as the first line is received, which enables early processing and partial reads.
 
-**3. Easy Appending**  
+**3. Incremental Retrieval**  
+A resolver that saves the state of a Log File (including the current size of the file), can retrieve (via HTTP header settings) and process only the entries added since the last read. This is efficient for applications that need to keep up with changes to DIDs without having to re-fetch the entire log.
+
+**4. Easy Appending**  
 New records can be added to the end of a file without modifying or re-serializing the existing content—ideal for systems that grow over time.
 
-**4. Simple Tooling**  
+**5. Simple Tooling**  
 Line-based formats work well with traditional Unix tools (`grep`, `awk`, `sed`) and can be parsed with minimal code in most languages.
 
-### Performance Trade-offs
+## Performance Trade-offs
 
 Benchmarks show that single JSON arrays may parse slightly faster in some environments. However, the practical benefits of JSON Lines—especially for scalability, simplicity, and streaming use cases—often outweigh the marginal performance difference.
 

--- a/docs/faq/Performance.md
+++ b/docs/faq/Performance.md
@@ -1,0 +1,34 @@
+# How Fast is did:webvh?
+
+Performance is an important aspect of any DID method, especially for those that are designed to handle large-scale data and frequent updates. Since did:webvh requires processing the entire DID Log file to verify a DID during resolution, it is crucial to understand how this impacts performance in real-world scenarios. This document provides some insights into the performance characteristics of did:webvh. We plan to add more detailed benchmarks in the future.
+
+## Scenario: An Enterprise DID With Monthly Key Rotations
+
+> The following example was submitted by [Glenn Gore] of [Affinidi], and is based on the Affinidi did:webvh Rust implementation, listed on the [implementations] page. The test code will soon be available -- we'll add a link here when it is.
+
+[Glenn Gore]: https://www.linkedin.com/in/goreg/
+[Affinidi]: https://affinidi.com
+[implementations]: ../implementations/README.md
+
+### Test Parameters
+
+- Enterprise has used did:webvh for 10 years
+- They use pre-authorised keys for LogEntries
+- They roll the keys every month, min 2 nextKeyHash
+- They randomly swap a witness node every 12 months
+  - Witness threshold: 3
+  - Number of witnesses maintained @ 4 Nodes
+- They randomly swap a watcher node every 12 months (offset by 6 months from the Witness Swap)
+
+The above is trying to simulate a realistic enterprise production deployment of did:webvh with security constraints.
+
+## Key results
+
+- did.jsonl = 197kb in size (120 LogEntries)
+- did-witness.json = 5.9KB in size (optimised)
+- Generating 120 LogEntries and creating proofs etc: Average ~50ms
+- Validating full did:webvh Log of 120 entries including full validation of Witness Proofs: Average ~28ms
+
+## Conclusion
+
+This is a very good performance result compared to other high-trust traceable DIDs. One can validate ~10 years of did:webvh history in under 30ms.

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -1,0 +1,5 @@
+# did:webvh Frequently Asked Questions
+
+This section has a collection of documents that answer common questions about the `did:webvh` specification and its implementation. It provides insights into the design choices, technical details, and practical considerations of using `did:webvh`.
+
+Have a topic that should be added? Please open an issue on the [did:webvh-info repository](https://github.com/decentralized-identity/didwebvh-info/issues).

--- a/docs/faq/WitnessFile.md
+++ b/docs/faq/WitnessFile.md
@@ -1,0 +1,66 @@
+# Why Have a Separate `witness.json` File in did:webvh?
+
+Some developers new to `did:webvh` have asked: *Why not just include witness proofs directly in the `did.jsonl` log file?* After all, embedding them could eliminate the need for a second file, eliminate the second file retrieval, and simplify the witness threshold verification complexity. Instead, we keep the witness proofs in a separate `witness.json` file, and use that separation to "optimize" the file by keeping only one (or two) proofs from each witness on the assumption that a proof from witness implies approval from the witness of all previous log entries.
+
+So in theory, we are trading off complexity in retrieval and processing to minimize the size and processing time of the witness proofs. What is impact of that tradeoff in practice? Is it worth it?  The article provides some real-world performance data to help answer that question.
+
+Thanks to [Glenn Gore] of [Affinidi], we have a test case that simulates a 10-year enterprise `did:webvh` DID to see how the two approaches compare in practice.
+
+[Glenn Gore]: https://www.linkedin.com/in/goreg/
+[Affinidi]: https://affinidi.com
+
+## Pros and Cons of Each Approach
+
+| Approach | Pros | Cons |
+|---------|------|------|
+| **Embedding Witness Proofs in Log Entries** | - One less file to retrieve<br>- Allows "sign-as-you-go" witnessing | - Increases log file size<br>- Eliminates the ability to reduce witness proofs<br>- More proofs to validate |
+| **Separate `witness.json` File** *(current approach)* | - Minimizes the number of witness proofs<br>- Smaller file size<br>- Fewer proofs to validate | - Requires a second file to be fetched<br>- Resolvers must implement more complex threshold calculation logic |
+
+## Performance Test: Realistic 10-Year `did:webvh` DID
+
+This is the same scenario as the [performance scenario] described in the [did:webvh Performance document], but with a focus on the impact of keeping witness proofs in a separate file.
+
+- 120 Log Entries (~1 per month for 10 years)
+- Keys rolled monthly using `nextKeyHash`
+- Witness threshold of 3, from 4 witness nodes
+- Witness node swapped annually
+- Watcher node also rotated annually (offset by 6 months)
+
+### With Optimized `witness.json` File
+
+- `did.jsonl` size: **197 KB**  
+- `witness.json` size: **5.9 KB**  
+- Time to generate log entries: ~**50ms**  
+- Time to validate the full DID history (including witness proofs): ~**28ms**
+
+> ✅ **Total validation time: under 30ms** for 10 years of history — faster than many other high-trust DID methods.
+
+### Keeping All Witness Proofs (Simulating Inlined Proofs)
+
+What happens if we *don’t* optimize witness proofs — simulating the effect of embedding them in every log entry? Although this test keeps the separate `witness.json` file, we keep all proofs from each witness for every log entry. It's not good:
+
+| Metric | With Optimization | Without Optimization | Impact |
+|--------|-------------------|-----------------------|--------|
+| `witness.json` size | **5.9 KB** ✅| **182 KB** | **~31× larger** |
+| Reading witness proofs | **7.25ms** ✅| **104ms** | **~14× slower** |
+| Proof validation time | **26.25ms** ✅| **77ms** | **~3× slower** |
+| **Total validation time** | **37ms** ✅| **185ms** | **~5× slower** |
+
+Glenn ran some additional tests with more witnesses, and the impact of the "all in the Log" solution was even more pronounced.
+
+Note that in the timing, the cost to fetch the two files across the internet is not included. So reducing the count from 2 reads to 1 would be a win for the "all in one" solution. However, that would be offset by the size of the one file being so much larger than the two combined.
+
+## Conclusion: Keeping `witness.json` Separate is a Win
+
+While inlining witness proofs in `did.jsonl` might seem simpler, it comes at a steep cost in file size and performance — especially as DID histories grow and with more witnesses.
+
+The current design, with a separate `witness.json` file:
+
+- ✅ Enables significant optimization (95%+ smaller file)
+- ✅ Dramatically improves validation speed (fewer proofs to verify)
+- ✅ Keeps `did:webvh` lightweight and scalable — even over decades of updates
+
+By decoupling witness proofs from the log entries, `did:webvh` retains the simplicity of `did:web` while adding scalable verifiability. It's a tradeoff that pays off.
+
+[performance scenario]: ./Performance.md#scenario-an-enterprise-did-with-monthly-key-rotations
+[did:webvh Performance document]: ./Performance.md#how-fast-is-didwebvh

--- a/docs/implementations/README.md
+++ b/docs/implementations/README.md
@@ -10,7 +10,7 @@ Implementations of `did:webvh` software for DID Controller registrars, resolvers
 - [Affinidi] -- [Rust](https://github.com/affinidi/affinidi-tdk-rs/tree/main/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh), [Crate](https://crates.io/crates/did-webvh) (Resolver)
 - [DIF] -- [`did:webvh` Server - Python](https://github.com/decentralized-identity/didwebvh-server-py) (Server)
 - [DIF] -- [`did:webvh` Watcher - Python](https://github.com/decentralized-identity/didwebvh-watcher-py) (Watcher)
-- [OWF] -- [ACA-Py Plugin for `did:webvh`]([did:webvh ACA-Py Plugin]: https://github.com/openwallet-foundation/acapy-plugins/tree/main/webvh) (DID Controller/Resolver Framework)
+- [OWF] -- [ACA-Py Plugin for `did:webvh`][https://github.com/openwallet-foundation/acapy-plugins/tree/main/webvh) (DID Controller/Resolver Framework)
 - [OWF] -- [Credo-TS Module for `did:webvh`](https://github.com/openwallet-foundation/credo-ts/pull/2238) (DID Resolver Framework)
 
 Please see each implementation's repository for details on features and capabilities.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,13 +80,17 @@ nav:
 - Welcome:
     - Introduction to did:webvh: README.md
     - Overview: overview.md
-    - Frequently Asked Questions: faq.md
     - DID Rubric Evaluation: did-rubric-evaluation.md
     - Work Item Meetings: agenda.md
     - did/whois: whois.md
     - Release Notes: version.md
 - The Specification:
     - Specification: specification.md
+- FAQ:
+    - Frequently Asked Questions: faq/README.md
+    - Why JSON Lines?: faq/JSONLines.md
+    - How fast is did:webvh?: faq/Performance.md
+    - Why a separate Witness File?: faq/WitnessFile.md
 - Implementer's Guide:
     - The `did:webvh` Implementer's Guide: implementers-guide/README.md
     - Implementing a `did:webvh` Resolver: implementers-guide/resolver-algorithm.md


### PR DESCRIPTION
Changes the FAQ to be a top-level section and adds an articles on performance and "why a witness file".

Should probably sort out the compatibility of the implementation before merging -- ideally including running the resolution of the DIDs through the existing implementations.
